### PR TITLE
README.mdの環境構築で実行するコマンドを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Girack-v-Backend(バックエンド) : https://github.com/NfoAlex/Girack-v-Backe
 ## 環境構築
 
 ```sh
+cd .\Girack-v\
 npm install
 ```
 


### PR DESCRIPTION
`npm install`とか`npm run dev`とか実行する前に移動するコマンドを追記
README.mdが置いてある場所じゃなくてその下の`Girack-v`に移動して実行するような手順に修正